### PR TITLE
Add tests for boolean logic

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -360,7 +360,6 @@ void set_number_variable(const char *name, int value)
     set_variable(name, term_new_number(value));
 }
 
-
 static const struct term *function_assign(const struct term *parameters)
 {
     const struct term *var = parameters;
@@ -389,9 +388,10 @@ static const struct term *function_info(const struct term *parameters)
 {
     while (parameters) {
         const struct term *str = term_to_string(parameters);
-        fprintf(stderr, "%s\n", str->string);
+        fprintf(stderr, "%s ", str->string);
         parameters = parameters->next;
     }
+    fprintf(stderr, "\n");
     return NULL;
 }
 

--- a/tests/004_bool_logic
+++ b/tests/004_bool_logic
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+#
+# Test boolean operator precedence
+#
+
+cat >$CONFIG <<EOF
+true && true || false || false && false -> info("&& and || logic works")
+true && (true || (false || false)) && false -> info("Should not print")
+
+true == true && false -> info("Should not print")
+(true == false) || false -> info("Paren precedence takes over logical operators: shouldn't print")
+EOF
+
+
+cat >$EXPECTED <<EOF
+fixture: mount("devtmpfs", "/dev", "devtmpfs", 10, data)
+fixture: mkdir("/mnt", 777)
+&& and || logic works
+fixture: mount("/dev/mmcblk0p2", "/mnt", "squashfs", 1, data)
+fixture: unlink("/init")
+fixture: rmdir("/root")
+fixture: mount("/dev", "/mnt/dev", "(null)", 8192, data)
+fixture: mount(".", "/", "(null)", 8192, data)
+fixture: chroot(.)
+Hello from the chained /sbin/init
+EOF


### PR DESCRIPTION
I can add math-related tests after #9 and #10 because otherwise, I am just testing that addition is associative and commutative which does not feel like too valuable of tests. Even so, #9 will make it hard to actually test because as long as there are numbers other than `0` as a result on either side of the `==` operator then the test will print. That is to say if the results of the addition are `1 == 3` it will still be considered true until #9 is fixed. 