### PR TITLE
Refactor commandline argument passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,17 +68,18 @@ uboot_env.start    | The block offset of the U-Boot environment. (512 byte block
 uboot_env.count    | The number of blocks in the environment. Defaults to 256.
 run_repl           | True to run a REPL before booting. This is useful for debug. Defaults to `false`
 
-Variables can be overridden using the Linux commandline via the
-`--nerves_initramfs` option. For example, to override `run_repl`, pass:
+Variables can be overridden using the Linux commandline. See your platform's
+bootloader documentation for how to pass options to Linux. At the end of the
+commandline, add a `--` and then add `variable` and `variable=value` strings.
+The `--` will stop the Linux kernel from processing parameters so make sure that
+everything intended for Linux is on the left side and everything for
+`nerves_initramfs` is on the right side.
+
+For example, the following Linux commandline sets the Linux console and then
+passes a root filesystem path to `nerves_initgadget` and starts a repl.
 
 ```text
---nerves_initramfs=run_repl
-```
-
-To set a variable:
-
-```text
---nerves_initramfs=rootfs.path=/dev/abc123
+console=tty1 -- rootfs.path=/dev/sda2 run_repl
 ```
 
 ### Functions

--- a/examples/demo/config/grub.cfg
+++ b/examples/demo/config/grub.cfg
@@ -6,6 +6,6 @@
 # boot linux fat part_msdos normal biosdisk
 #
 
-linux /boot/bzImage console=ttyS0 --nerves_initramfs=rootfs.path=PARTUUID=44332211-03
+linux /boot/bzImage console=ttyS0 -- hello_from_grub
 initrd /boot/nerves_initramfs
 boot

--- a/src/nerves_initramfs.c
+++ b/src/nerves_initramfs.c
@@ -248,16 +248,26 @@ static void initialize_script_defaults(int argc, char *argv[])
 
     set_boolean_variable("run_repl", false);
 
-    // Scan the commandline for more parameters to set
-    // Parameters are of the form:
+    // Scan the commandline for more parameters to set. Our instructions tell
+    // users to put options for us after a `--`. The `--` isn't passed in the
+    // argument list, so we can't search for that. However, Linux won't remove
+    // or process anything after the `--` and that is a big deal to avoid
+    // confusing clashes with Linux options.
     //
-    //   --nerves_initramfs=key
+    // Parameters have the form:
+    //
+    //   key
     // or
-    //   --nerves_initramfs=key=value
+    //   key=value
+    //
+    // In the first case, `key` is set to `true`. For the second
+    // case, the value is always interpreted as a string.
+    debug("argc=%d, argv[0]='%s'", argc, argv[0]);
     for (int i = 1; i < argc; i++) {
         debug("argv[%d]='%s'", i, argv[i]);
-        if (strncmp("--nerves_initramfs=", argv[i], 19) == 0) {
-            char *key = argv[i] + 19;
+
+        if (argv[i][0] != '-') {
+            char *key = argv[i];
             char *equals = strchr(key, '=');
 
             if (equals) {

--- a/tests/003_cmdline_override
+++ b/tests/003_cmdline_override
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 #
-# Test that no options does the expected
+# Test that specifying an option gets picked up
 #
 
 cat >$CMDLINE_FILE <<EOF
---nerves_initramfs=rootfs.fstype=myfstype
+--run_repl -another_thing_that_should_be_ignored rootfs.fstype=myfstype
 EOF
 
 cat >"$EXPECTED" <<EOF


### PR DESCRIPTION
The Linux kernel intercepts a LOT of different ways of passing
commandline parameters. This is very confusing, but makes sense from the
Linux kernel's perspective. To make things less confusing for
`nerves_initramfs` users, add instructions for passing all commandline
args after a `--` on the commandline. Linux won't process anything after
that. This also allows simplifications to the parameters to just
key=value or just key. See the README.md for examples.