### PR TITLE
DM takes blocks and not bytes

### DIFF
--- a/tests/002_encrypted_fs
+++ b/tests/002_encrypted_fs
@@ -18,9 +18,10 @@ fixture: mkdir("/proc", 555)
 fixture: mount("devtmpfs", "/dev", "devtmpfs", 10, data)
 fixture: mount("sysfs", "/sys", "sysfs", 14, data)
 fixture: mount("proc", "/proc", "proc", 14, data)
+fixture: ioctl(BLKSSZGET)
 fixture: ioctl(LOOP_SET_FD)
 fixture: ioctl(DM_DEV_CREATE, data_size=16384, data_start=312, target_count=0, open_count=0, flags=0, event_nr=0, dev=0x0, name=rootfs, uuid=CRYPT-PLAIN-rootfs
-fixture: ioctl(DM_TABLE_LOAD, data_size=16384, data_start=312, target_count=1, open_count=0, flags=32768, event_nr=0, dev=0x0, name=rootfs, uuid=, target=0,524288,crypt (aes-cbc-plain 8e9c0780fd7f5d00c18a30812fe960cfce71f6074dd9cded6aab2897568cc856 0 /dev/loop0 0)
+fixture: ioctl(DM_TABLE_LOAD, data_size=16384, data_start=312, target_count=1, open_count=0, flags=32768, event_nr=0, dev=0x0, name=rootfs, uuid=, target=0,1024,crypt (aes-cbc-plain 8e9c0780fd7f5d00c18a30812fe960cfce71f6074dd9cded6aab2897568cc856 0 /dev/loop0 0)
 fixture: ioctl(DM_DEV_SUSPEND, data_size=16384, data_start=312, target_count=0, open_count=0, flags=32768, event_nr=0, dev=0x0, name=rootfs, uuid=
 fixture: mount("/dev/dm-0", "/mnt", "squashfs", 1, data)
 fixture: mount("/dev", "/mnt/dev", "(null)", 8192, data)

--- a/tests/fixture/init_fixture.c
+++ b/tests/fixture/init_fixture.c
@@ -530,6 +530,19 @@ OVERRIDE(int, ioctl, (int fd, unsigned long request, ...))
         req = "LOOP_SET_FD";
         break;
 
+    case BLKSSZGET:
+    {
+        va_list ap;
+        va_start(ap, request);
+        size_t *block_size = va_arg(ap, size_t *);
+
+        *block_size = 512;
+
+        va_end(ap);
+        req = "BLKSSZGET";
+        break;
+    }
+
     default:
         log("unknown ioctl(0x%08lx)", request);
         req = "unknown";


### PR DESCRIPTION
This fixes the following error:

```
device-mapper: table: 254:0: loop0 too small for target: start=0, len=536870912, dev_size=1048576
```