### PR TITLE
Notes on dealing with cpio files 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ build_initramfs: &build_initramfs
         command: |
           mkdir -p ~/deploy/artifacts
           cp CHANGELOG.md ~/deploy/CHANGELOG.md
+          cp file-to-cpio.sh ~/deploy/artifacts
     - run:
         name: Build initramfs images
         command: |
@@ -119,6 +120,7 @@ jobs:
           command: |
             mkdir -p ~/deploy/artifacts/nerves_initramfs-$CIRCLE_TAG
             mv ~/deploy/artifacts/nerves_initramfs_* ~/deploy/artifacts/nerves_initramfs-$CIRCLE_TAG
+            mv ~/deploy/artifacts/file-to-cpio.sh ~/deploy/artifacts/nerves_initramfs-$CIRCLE_TAG
             cd ~/deploy/artifacts && tar cfz nerves_initramfs-$CIRCLE_TAG.tar.gz nerves_initramfs-$CIRCLE_TAG
             cd ~/deploy/artifacts && sha256sum nerves_initramfs-$CIRCLE_TAG.tar.gz > nerves_initramfs-$CIRCLE_TAG.tar.gz.sha256
             rm -fr ~/deploy/artifacts/nerves_initramfs-$CIRCLE_TAG

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ cd o/arm
 make
 ```
 
-The `initramfs` images will be in the `images` directory. You can also run `make
+The `nerves_initramfs` images will be in the `images` directory. You can also run `make
 menuconfig` to enable other applications and libraries that may be useful for
 your particular setup.
 

--- a/file-to-cpio.sh
+++ b/file-to-cpio.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 #
-# config-to-cpio.sh <nerves_initramfs.conf> <output.cpio[.gz|.xz]>
+# file-to-cpio.sh <file.ext> <output.cpio[.gz|.xz]>
 #
-# This script packages the specified nerves_initramfs.conf file into an
-# optionally-compressed cpio file that can be concatenated to
-# nerves_initramfs.cpio.* to configure the initramfs.
+# This script packages the specified file into an optionally-compressed 
+# cpio file that can be concatenated to other *.cpio.* files for
+# configuring the initramfs.
 #
 # If you need to supply more files to the initramfs, just concatenate another
 # cpio (compressed or not) onto this one. The Linux kernel's cpio extractor
@@ -16,7 +16,7 @@ INPUT=$1
 OUTPUT=$2
 
 if [ -z $INPUT ]; then
-    echo "Please pass in a path to a configuration file"
+    echo "Please pass in a path to a file"
     exit 1
 fi
 
@@ -36,11 +36,14 @@ case "$OUTPUT" in
     *) COMPRESS=cat;;
 esac
 
+FILENAME=$(basename $INPUT)
 WORKDIR=$(mktemp -d)
-cp $INPUT $WORKDIR/nerves_initramfs.conf
-(cd $WORKDIR; echo nerves_initramfs.conf | cpio -o -H newC --owner=root:root --reproducible --quiet | $COMPRESS > "$ABSOLUTE_OUTPUT")
-rm $WORKDIR/nerves_initramfs.conf
+
+echo "CPIO File: $FILENAME"
+
+cp $INPUT $WORKDIR/$FILENAME
+(cd $WORKDIR; echo $FILENAME | cpio -o -H newC --owner=root:root --reproducible --quiet | $COMPRESS > "$ABSOLUTE_OUTPUT")
+rm $WORKDIR/$FILENAME
 rmdir $WORKDIR
 
 exit 0
-


### PR DESCRIPTION
* Adds some notes about cpio file requirment.
* Adjusts some instructions for working with rpi.
* Changes `config-to-cpio.sh` to `file-to-cpio.sh` and includes it in the release so that it can be used in packages when prepping config and revert files.